### PR TITLE
Rename solution and project to match c# naming style

### DIFF
--- a/Functions/AuthFunctions.cs
+++ b/Functions/AuthFunctions.cs
@@ -15,14 +15,14 @@ namespace Ticketinho
         }
 
         [Function("Login")]
-        public HttpResponseData Login([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
+        public HttpResponseData Login([HttpTrigger(AuthorizationLevel.Anonymous, "post")] HttpRequestData req)
         {
             _logger.LogInformation("C# HTTP trigger function processed a request.");
-
+            
             var response = req.CreateResponse(HttpStatusCode.OK);
             response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
 
-            response.WriteString("Welcome to Azure Functions!");
+            response.WriteString("Welcome to Azure Functions!!");
 
             return response;
         }

--- a/Ticketinho.csproj
+++ b/Ticketinho.csproj
@@ -5,12 +5,13 @@
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <RootNamespace>ticketinho_back</RootNamespace>
+    <RootNamespace>Ticketinho</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.14.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.10.0" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Ticketinho.sln
+++ b/Ticketinho.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.002.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ticketinho-back", "ticketinho-back.csproj", "{83650C38-A97C-43DA-A35E-FFC6389A81A7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ticketinho", "Ticketinho.csproj", "{83650C38-A97C-43DA-A35E-FFC6389A81A7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
I didn't notice that the solution name was with an underscore when creating the project.
I think is best to use PascalCase for that.